### PR TITLE
chore: add redirects for deprecated routes

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -20,6 +20,64 @@ module.exports = withNextra({
         destination: "/getting-started/overview",
         permanent: true,
       },
+
+      // old doc links used in cli 0.63.6 and below
+      {
+        source: "/references/connection-strings",
+        destination: "/guides/postgresql#connection-strings",
+        permanent: false,
+      },
+      {
+        source: "/references/connection-strings/#troubleshooting",
+        destination: "/guides/postgresql#troubleshooting-connection-strings",
+        permanent: false,
+      },
+      {
+        source: "/references/configuration-files",
+        destination: "/reference/configuration",
+        permanent: false,
+      },
+      {
+        source: "/getting-started/start-here",
+        destination: "/getting-started/overview",
+        permanent: false,
+      },
+      {
+        source: "/getting-started/data-operations",
+        destination: "/core-concepts/reference/configuration",
+        permanent: false,
+      },
+      {
+        source:
+          "/tutorials/supabase-clone-environments#step-6-restore-the-data-target",
+        destination: "/recipes/supabase#6-restore-the-data-target",
+        permanent: false,
+      },
+      {
+        source: "/references/data-operations/generate",
+        destination: "/reference/configuration#generate",
+        permanent: false,
+      },
+      {
+        source: "/references/data-operations/exclude",
+        destination: "/reference/configuration#select",
+        permanent: false,
+      },
+      {
+        source: "/references/data-operations/transform",
+        destination: "/reference/configuration#transform",
+        permanent: false,
+      },
+      {
+        source: "/references/data-operations/reduce",
+        destination: "/reference/configuration#subset",
+        permanent: false,
+      },
+      {
+        source: "/references/data-operations/introspect",
+        destination: "/reference/configuration#introspect",
+        permanent: false,
+      },
     ];
   },
 });

--- a/pages/guides/postgresql.mdx
+++ b/pages/guides/postgresql.mdx
@@ -81,3 +81,31 @@ During the snapshot capture process, use `NODE_TLS_REJECT_UNAUTHORIZED=0`:
 ```bash >_&nbsp;terminal
 NODE_TLS_REJECT_UNAUTHORIZED=0 SNAPLET_DATABASE_URL='postgresql://<user>:<password>@<host>:<port>/<database>?sslmode=required&ssl=true&sslmode=require' snaplet snapshot capture
 ```
+
+## Connection strings
+
+> Also known as Connection URLs
+
+To connect to your database the CLI requires database credentials in the form of a connection string. A PostgreSQL connection url specifies the following parameters:
+
+- username (the username used to connect to the database)
+- password (the password used in the "user" parameter)
+- hostname (the IP address or domain name of the machine where the server is running)
+- port (port number on which the server is listening on)
+- database (name of the database to connect to)
+
+This connection string will also include a collection of parameter keywords (optional) that allow adjustments of various aspects of the url (e.g. SSL, timeouts, etc)
+
+**Here's an example connection string:**
+
+```bash
+postgresql://username:password@hostname:5432/database_name
+```
+
+### Troubleshooting connection strings
+
+When passing in a connection string to Snaplet, we will attempt to validate and encode the connection string, however you may still have problems with database names or passwords and special characters **`(%&/:=?@[])`**, in this case you may have to encode these characters manually.
+
+> **Encoding manually:** you can manually encode individual segments of your connection url (password, database, etc.) using [encodeURIComponent](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURIComponent)
+
+If you still have problems configuring your connection string, refer to this [short guide](https://www.prisma.io/dataguide/postgresql/short-guides/connection-uris) or reach out to us on [discord](https://app.snaplet.dev/chat) instead.


### PR DESCRIPTION
We recently moved this repo to `docs.snaplet.dev`, some routes were updated or removed, leading to broken links in the Snaplet CLI and Web app. To avoid users getting 404 messages when clicking on links in the CLI versions >= 0.63.6; In this pr we are adding redirect rules that will redirect the user to the correct routes.