### PR TITLE
fix: add Prisma seeding guide redirect

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -78,6 +78,11 @@ module.exports = withNextra({
         destination: "/reference/configuration#introspect",
         permanent: false,
       },
+      {
+        source: "/tutorials/prisma-seed",
+        destination: "/recipes/prisma",
+        permanent: false,
+      },
     ];
   },
 });


### PR DESCRIPTION
https://docs.snaplet.dev/tutorials/prisma-seed is currently being used in Prisma's docs and we caught it using our link checker. I've added a redirect that will point to the new path — https://docs.snaplet.dev/recipes/prisma