### PR TITLE
Explain the `@snaplet/seed` workflow

### DIFF
--- a/pages/core-concepts/seed.mdx
+++ b/pages/core-concepts/seed.mdx
@@ -30,23 +30,7 @@ Let's see how it works.
 
 ## The workflow
 
-If you have run `snaplet setup`, you are
-
-### Setup
-
-## Regenerating `@snaplet/seed` assets
-
-`@snaplet/seed` provides you with a client library that corresponds to your database structure. To do this, snaplet looks at your database structure and uses this to generates assets that `@snaplet/seed` can use to provide this client library.
-
-Whenever your database structure changes, `@snaplet/seed` will need these assets to be regenerated so that they are in sync with your new database structure.
-
-If you are familiar with [`@prisma/client`](https://www.prisma.io/docs/concepts/components/prisma-client), you can think of `snaplet generate` doing the same thing, just in this case for `@snaplet/seed` rather than `@prisma/client`.
-
-You can regenerate these assets by running:
-
-```
-npx snaplet generate
-```
+TODO
 
 ## Generating data with `@snaplet/seed`
 

--- a/pages/core-concepts/seed.mdx
+++ b/pages/core-concepts/seed.mdx
@@ -28,6 +28,26 @@ The key to effortless generated data is a tool that deeply understands your data
 
 Let's see how it works.
 
+## The workflow
+
+If you have run `snaplet setup`, you are
+
+### Setup
+
+## Regenerating `@snaplet/seed` assets
+
+`@snaplet/seed` provides you with a client library that corresponds to your database structure. To do this, snaplet looks at your database structure and uses this to generates assets that `@snaplet/seed` can use to provide this client library.
+
+Whenever your database structure changes, `@snaplet/seed` will need these assets to be regenerated so that they are in sync with your new database structure.
+
+If you are familiar with [`@prisma/client`](https://www.prisma.io/docs/concepts/components/prisma-client), you can think of `snaplet generate` doing the same thing, just in this case for `@snaplet/seed` rather than `@prisma/client`.
+
+You can regenerate these assets by running:
+
+```
+npx snaplet generate
+```
+
 ## Generating data with `@snaplet/seed`
 
 You can refer to the [Seed Quick Start Guide](/getting-started/quick-start/seed) to learn about the basics of `@snaplet/seed`.
@@ -535,17 +555,3 @@ await snaplet.users([{
 ```
 
 The `override` option is applied on top of the `inflection` option, it's perfect for one-off changes.
-
-## Regenerating `@snaplet/seed` assets
-
-`@snaplet/seed` provides you with a client library that corresponds to your database structure. To do this, snaplet looks at your database structure and uses this to generates assets that `@snaplet/seed` can use to provide this client library.
-
-Whenever your database structure changes, `@snaplet/seed` will need these assets to be regenerated so that they are in sync with your new database structure.
-
-If you are familiar with [`@prisma/client`](https://www.prisma.io/docs/concepts/components/prisma-client), you can think of `snaplet generate` doing the same thing, just in this case for `@snaplet/seed` rather than `@prisma/client`.
-
-You can regenerate these assets by running:
-
-```
-npx snaplet generate
-```

--- a/pages/core-concepts/seed.mdx
+++ b/pages/core-concepts/seed.mdx
@@ -22,21 +22,64 @@ Here's why it's beneficial:
 
 While generated data might be the unsung hero of early development, it can get a bit needy as software evolves. But don't sweat it! Our mission is to save you from the never-ending saga of maintaining those seed scripts. Who has time for that, right?
 
-## Introducing `@snaplet/seed`
+## The workflow at a glance
 
-The key to effortless generated data is a tool that deeply understands your database's schema. By introspecting your database, we are able to create a fully-typed client dedicated to data generation.
+Using Snaplet to seed data will typically look something like this:
 
-Let's see how it works.
+1. Initial setup with `npx snaplet setup`
+2. Using `@snaplet/seed` to generate seed data
+3. Regenerating assets as your database changes with `npx snaplet generate`
 
-## The workflow
+You can also refer to the [Seed Quick Start Guide](/getting-started/quick-start/seed) for a practical example of the workflow.
 
-TODO
+### 1. Initial setup with `npx snaplet setup`
+
+At the start, you'll setup Snaplet for your project with `npx snaplet setup`, and follow the interactive prompts.
+
+`snaplet setup` will look at your database and its structure, and use it to generate the configuration files and assets needed by `@snaplet/seed`.
+
+### 2. Using `@snaplet/seed` to generate seed data
+
+`@snaplet/seed` is what you'll use to _actually_ generate data. It is a javascript library, giving you a fully-typed programmatic interface tailored to your database structure, which you'll use to describe _how_ data should be generated.
+
+Most commonly you'll write and run seed scripts that use `@snaplet/seed`. If you write your seed scripts in typescript, [tsx](https://www.npmjs.com/package/tsx) might come in handy for running your scripts:
+
+```bash >_&nbsp;terminal
+npx tsx seed.mts
+```
+
+Writing and running vanilla javascript works too:
+
+```bash >_&nbsp;terminal
+# a vanilla javascript file that uses `@snaplet/seed`
+node seed.js
+```
+
+You can also use `@snaplet/seed` in other scenarios - for example, in your tests.
+
+For more detail on using `@snaplet/seed`, check out [Generating data with `@snaplet/seed`](#generating-data-with-snapletseed) below.
+
+### 3. Regenerating assets as your database changes with `npx snaplet generate`
+
+`@snaplet/seed` provides you with a client library that corresponds to your database structure. To do this, snaplet looks at your database structure and uses this to generate assets that `@snaplet/seed` can use to provide this client library.
+
+Whenever your database structure changes, `@snaplet/seed` will need these assets to be regenerated so that they are in sync with your new database structure.
+
+You can regenerate these assets by running:
+
+```bash >_&nbsp;terminal
+npx snaplet generate
+```
+
+If you are familiar with [`@prisma/client`](https://www.prisma.io/docs/concepts/components/prisma-client), you can think of `snaplet generate` doing the same thing, just in this case for `@snaplet/seed` rather than `@prisma/client`.
 
 ## Generating data with `@snaplet/seed`
 
 You can refer to the [Seed Quick Start Guide](/getting-started/quick-start/seed) to learn about the basics of `@snaplet/seed`.
 
-### Inside the workflow
+For more, check out the [Seed Quick Start Guide](/getting-started/quick-start/seed).
+
+### Inside the `@snaplet/seed` workflow
 
 #### Deterministic data generation
 

--- a/pages/getting-started/quick-start/seed.mdx
+++ b/pages/getting-started/quick-start/seed.mdx
@@ -69,10 +69,10 @@ In order to have Snaplet generate this data, you'll need to tell Snaplet _how_ t
 
 This is where `@snaplet/seed` comes in: it gives you a programmatic interface to describe your seeding requirements.
 
+<CH.Scrollycoding className="seed-tutorial-configuration-file">
+
 `snaplet setup` would have generated an example script file called `seed.mts` in your project, which imports and
 uses `@snaplet/seed`. It should look something like this:
-
-<CH.Scrollycoding className="seed-tutorial-configuration-file">
 
 ```ts seed.mts
 import { SnapletClient } from '@snaplet/seed';

--- a/pages/getting-started/quick-start/seed.mdx
+++ b/pages/getting-started/quick-start/seed.mdx
@@ -64,15 +64,13 @@ npx snaplet setup
 
 ### Describing your requirements
 
-We now have a database with structure in it, and we have snaplet set up to use this database and its structure.
-
-We still do not yet have data though. In order to have Snaplet generate this data, you'll need to tell Snaplet _how_ to generate the data.
+We now have a database with structure in it, and Snaplet set up to use it. We still do not yet have data though.
+In order to have Snaplet generate this data, you'll need to tell Snaplet _how_ to generate the data.
 
 This is where `@snaplet/seed` comes in: it gives you a programmatic interface to describe your seeding requirements.
 
-`snaplet setup` would have generated an example script file called `seed.mts` in your project, which imports and uses `@snaplet/seed`.
-
-It should look something like this:
+`snaplet setup` would have generated an example script file called `seed.mts` in your project, which imports and
+uses `@snaplet/seed`. It should look something like this:
 
 <CH.Scrollycoding className="seed-tutorial-configuration-file">
 

--- a/pages/getting-started/quick-start/seed.mdx
+++ b/pages/getting-started/quick-start/seed.mdx
@@ -15,7 +15,6 @@ This guide will take you through the process of using `@snaplet/seed` to create 
 
 ## Prerequisites
 
-- You'll need to have the [Snaplet CLI](/getting-started/installation) installed and have run `snaplet setup`
 - Node.js and npm installed on your machine
 - a PostgreSQL database server running
 
@@ -51,30 +50,31 @@ The diagram above represents the relationships of your database.
 
 From the SQL tab above, copy the SQL statement and insert this into your database to define your schema.
 
-## Snaplet seed
+## Setting up snaplet
 
-We've now got a new database and a schema that lays out the structure of your data, but no actual data. This is where we can now use Snaplet to seed your database with production-like data.
+We now need to add snaplet to your project.
 
-For your example blog application, let's assume we need the following data:
+Run the following in your project root directory and follow the interactive prompts:
 
-- A post titled "Hello World!"
-- A post author, with an email address that ends with "acme.org."
-- Three comments on the post.
+```bash >_&nbsp;terminal
+npx snaplet setup
+```
 
-It's worth noting what we're not explicitly defining - that each comment needs to have a separate, unique author, for instance. We're assuming that `@snaplet/seed` will fill in the blanks based on your schema and seed realistic data as needed.
+## `@snaplet/seed`
 
 ### Describing your requirements
 
-In order to have Snaplet seed this data for your blog, we need to describe these requirements to `@snaplet/seed`.
+We now have a database with structure in it, and we have snaplet set up to use this database and its structure.
+
+We still do not yet have data though. In order to have Snaplet generate this data, you'll need to tell Snaplet _how_ to generate the data.
+
+This is where `@snaplet/seed` comes in: it gives you a programmatic interface to describe your seeding requirements.
+
+`snaplet setup` would have generated an example script file called `seed.mts` in your project, which imports and uses `@snaplet/seed`.
+
+It should look something like this:
 
 <CH.Scrollycoding className="seed-tutorial-configuration-file">
-
-First, we need to create a new seed script file that imports `@snaplet/seed`.
-
-This can be any javascript file that can be run by Node.js, but we recommend creating a typescript file for the best developer experience.
-
-- If you chose to have Snaplet seed an example for you during `snaplet setup`, you should have `seed.mts` file in your project that looks something like the code below.
-- If you chose to not have Snaplet seed an example, create a `seed.mts` file in your project (the directory where you ran `snaplet setup`) that looks like this:
 
 ```ts seed.mts
 import { SnapletClient } from '@snaplet/seed';
@@ -85,6 +85,14 @@ await snaplet.$resetDatabase()
 ```
 
 ---
+
+For your example blog application, let's assume we need the following data:
+
+- A post titled "Hello World!"
+- A post author, with an email address that ends with "acme.org."
+- Three comments on the post.
+
+It's worth noting what we're not explicitly defining - that each comment needs to have a separate, unique author, for instance. We're assuming that `@snaplet/seed` will fill in the blanks based on your schema and seed realistic data as needed.
 
 `snaplet` in the code above exposes all your models (i.e. your database tables, or the entities in your application - in this case "user" and "post") as functions.
 
@@ -309,6 +317,18 @@ DRY=0 npx tsx seed.mts
 ```
 
 All done, you're now ready to code against your generated data!
+
+### Evolving your application
+
+Whenever your database structure changes, `@snaplet/seed` will need to be re-generated so that it is in sync with your new database structure.
+
+You can do this by running:
+
+```bash >_&nbsp;terminal
+npx snaplet generate
+```
+
+If you are familiar with [`@prisma/client`](https://www.prisma.io/docs/concepts/components/prisma-client), you can think of `snaplet generate` doing the same thing, just in this case for `@snaplet/seed` rather than `@prisma/client`.
 
 ## Next steps
 


### PR DESCRIPTION
 ## Context
A recent support discussion showed that our docs and snaplet setup output need to clarify that snaplet setup just sets things up for the user to modify a seed script - i.e. that it doesn't do the seed work itself.

More generally, we need to explain the workflow the user should be expecting: setup with `npx snaplet setup`, usage with `@snaplet/seed`, re-generating assets with `snaplet generate`.

 ## Changes
* Explain the workflow at a glance in core concepts page
* Explain each step in the workflow in getting started guide