### PR TITLE
include script for restoring supabase user privileges

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -80,6 +80,11 @@ module.exports = withNextra({
         permanent: true,
       },
       {
+        source: '/tutorials/neon',
+        destination: '/recipes/neon',
+        permanent: true,
+      },
+      {
         source: '/tutorials/prisma-seed',
         destination: '/recipes/prisma',
         permanent: true,

--- a/pages/recipes/supabase.mdx
+++ b/pages/recipes/supabase.mdx
@@ -216,23 +216,54 @@ service_role key: eyJh......
 
 #### 5: Config setup
 
-You're now ready to restore your production snapshot into your Supabase development project.
+1. Navigate to your project directory.
 
-1. Navigate to your project directory
-2. Run `snaplet setup`
+2. Set up your snaplet config.
 
-   1. You will be shown a warning to write `.snaplet/config` in your project directory. Select yes (y) to create the file.
-   2. Then you will be asked for a **target database connection string.** . Paste in the **DB URL** you copied in step 3.
+```bash >_&nbsp;terminal
+snaplet setup
+```
 
-3. Run `snaplet project setup` - you will be presented with a list of projects, these are databases that are connected to your Snaplet account. Choose the project that contains the snapshot you created in step 2.
+```bash >_&nbsp; terminal
+# mark
+✔ Welcome to Snaplet! 😸 Choose your adventure: › I want to capture or restore a snapshot 💾
+
+Target database credentials
+Snaplet restores data to your target database using the target database credentials.
+
+Read more: https://docs.snaplet.dev/guides/postgresql#connection-strings
+
+# mark
+✔ Target database connection string … postgresql://postgres:postgres@localhost:54322/postgres
+📡 Connected to database with "[secret]ql://postgres:postgres@localhost:54322/postgres"
+
+# mark
+✔ Select or create a project › My Team > My Project
+
+You're all set! Take a look at our docs to find out what you can do from here:
+https://docs.snaplet.dev/getting-started/start-here/
+
+Restore latest snapshot:
+To restore the latest snapshot in your project execute the command:
+snaplet ss restore --latest
+
+Local capture:
+You can learn more about self hosting here: https://docs.snaplet.dev/guides/self-hosting
+
+To capture a snapshot of your local database first pull the full configuration with:
+snaplet config pull
+
+Then capture the snapshot with:
+SNAPLET_SOURCE_DATABASE_URL=<database-url> snaplet ss capture
+```
 
 #### 6: Restore the data target
 
 You are now ready to restore!
 
-1. Run `snaplet snapshot restore --no-reset` in your project path.
+1. Run `snaplet snapshot restore` in your project path.
 
-> **Note on `--no-reset`**: This will skip the “reset” step of the restore command. So no existing schemas will be dropped. Learn more about data operations [here](/core-concepts/capture)
+> **Note:** for supabase projects we automatically include the `--no-reset` flag when running `snaplet snapshot restore`. So no existing schemas will be dropped. Learn more about data operations [here](/core-concepts/capture)
 
 ![Supabase is fun!](/recipes/supabase/snappy-with-supabase-ball.svg)
 
@@ -286,37 +317,6 @@ defineConfig({
 ```
 
 During onboarding, this `select` option is automatically added to your config. In the web editor you will be shown a warning, if you choose to remove the `$default` field.
-
-#### Restoring into a Supabase project
-
-You may run into problems restoring to a Supabase project hosted in the cloud. This is because the snaplet restore command will drop your database first, before restoring any schemas and tables, which results in your project being in a broken state. The reason for this is that Snaplet was unable to restore schemas that Supabase requires a super user role to perform write operations.
-
-By default Snaplet drop the database before Restoring. This may include privileges or roles that are required for your Supabase project to function correctly. 
-To get around this, run the `restore` command with the `--no-reset` flag, e.g:
-
-```bash >_&nbsp;terminal
-snaplet snapshot restore --no-reset
-```
-
-If you wish to restore without the `--no-reset` flag, you can run the following script in your SQL editor after restoring:
-
-```sql
-grant usage on schema public to postgres, anon, authenticated, service_role;
-
-grant all privileges on all tables in schema public to postgres, anon, authenticated, service_role;
-grant all privileges on all functions in schema public to postgres, anon, authenticated, service_role;
-grant all privileges on all sequences in schema public to postgres, anon, authenticated, service_role;
-
-alter default privileges in schema public grant all on tables to postgres, anon, authenticated, service_role;
-alter default privileges in schema public grant all on functions to postgres, anon, authenticated, service_role;
-alter default privileges in schema public grant all on sequences to postgres, anon, authenticated, service_role;
-```
-
-Running this script after restoring will prevent you from running into warnings like:
-
-```
-permission denied for schema public
-```
 
 #### Reset supabase database
 

--- a/pages/recipes/supabase.mdx
+++ b/pages/recipes/supabase.mdx
@@ -317,3 +317,16 @@ Running this script after restoring will prevent you from running into warnings 
 ```
 permission denied for schema public
 ```
+
+#### Reset supabase database
+
+Use the `supabase db reset` command to reset the state of your Supabase project. 
+This is useful for cases a snapshot breaks your project, or you want to start from a clean slate.
+
+```bash >_&nbsp;terminal
+# reset your supabase database
+supabase db reset
+
+# restore your snapshot
+supabase snapshot restore
+```

--- a/pages/recipes/supabase.mdx
+++ b/pages/recipes/supabase.mdx
@@ -291,8 +291,29 @@ During onboarding, this `select` option is automatically added to your config. I
 
 You may run into problems restoring to a Supabase project hosted in the cloud. This is because the snaplet restore command will drop your database first, before restoring any schemas and tables, which results in your project being in a broken state. The reason for this is that Snaplet was unable to restore schemas that Supabase requires a super user role to perform write operations.
 
+By default Snaplet drop the database before Restoring. This may include privileges or roles that are required for your Supabase project to function correctly. 
 To get around this, run the `restore` command with the `--no-reset` flag, e.g:
 
 ```bash >_&nbsp;terminal
 snaplet snapshot restore --no-reset
+```
+
+If you wish to restore without the `--no-reset` flag, you can run the following script in your SQL editor after restoring:
+
+```sql
+grant usage on schema public to postgres, anon, authenticated, service_role;
+
+grant all privileges on all tables in schema public to postgres, anon, authenticated, service_role;
+grant all privileges on all functions in schema public to postgres, anon, authenticated, service_role;
+grant all privileges on all sequences in schema public to postgres, anon, authenticated, service_role;
+
+alter default privileges in schema public grant all on tables to postgres, anon, authenticated, service_role;
+alter default privileges in schema public grant all on functions to postgres, anon, authenticated, service_role;
+alter default privileges in schema public grant all on sequences to postgres, anon, authenticated, service_role;
+```
+
+Running this script after restoring will prevent you from running into warnings like:
+
+```
+permission denied for schema public
 ```


### PR DESCRIPTION
A user reported, the following error, when running queries in their Supabase app.

```
permission denied for schema public
```

The supabase sdk uses the "postgres" user to perform queries in a schema's table. If `snaplet restore`, is ran without the `--no-reset`, the default privileges for this user are dropped and not restored. This may also be true for other users.

To restore the privileges, the user should run this script in after restoring with Snaplet.

This is only required for restores, missing the `--no-reset` flag. In the future this flag will automatically be inserted for Supabase users.