### PR TITLE
Fix broken tabs in install instructions

### DIFF
--- a/pages/getting-started/installation.mdx
+++ b/pages/getting-started/installation.mdx
@@ -65,6 +65,7 @@ We look for a package manager lockfile for npm, pnpm, yarn, or bun. If you do no
   ```
   </Tab>
   <Tab>
+  ```bash >_&nbsp;terminal
   pnpm --save-dev snaplet @snaplet/seed
   ```
   </Tab>
@@ -73,7 +74,7 @@ We look for a package manager lockfile for npm, pnpm, yarn, or bun. If you do no
   yarn add --dev snaplet @snaplet/seed
   ```
   </Tab>
-    <Tab>
+  <Tab>
   ```bash >_&nbsp;terminal
   bun add --dev snaplet @snaplet/seed
   ```


### PR DESCRIPTION
On page [Installation > Installing dependencies](https://docs.snaplet.dev/getting-started/installation#installing-dependencies), tabs were broken:

## Before
![image](https://github.com/snaplet/docs/assets/1181770/1f6887b3-0edf-400b-b504-3a5d71ca7329)

## After
![image](https://github.com/snaplet/docs/assets/1181770/6dae6e80-6134-4a35-8da8-c3be376b1b91)
