### PR TITLE
fix: pnpm install command

### DIFF
--- a/pages/getting-started/installation.mdx
+++ b/pages/getting-started/installation.mdx
@@ -66,7 +66,7 @@ We look for a package manager lockfile for npm, pnpm, yarn, or bun. If you do no
   </Tab>
   <Tab>
   ```bash >_&nbsp;terminal
-  pnpm --save-dev snaplet @snaplet/seed
+  pnpm add --save-dev snaplet @snaplet/seed
   ```
   </Tab>
   <Tab>


### PR DESCRIPTION
The `add` keyword was missing from the `pnpm` install command.