### PR TITLE
fix: Reference self hosting guide for setup

### DIFF
--- a/pages/snapshot/getting-started/installation.mdx
+++ b/pages/snapshot/getting-started/installation.mdx
@@ -2,12 +2,7 @@ import { Tabs, Tab } from "nextra/components";
 
 # Installation
 
-## For snapshots
-Snaplet can either be self-hosted or accessed as a web app via our cloud service, Snaplet cloud. The choice is yours!
-
-We recommend beginning with [Snaplet cloud](https://snaplet.dev). Sign up for free and start utilizing your data in mere minutes!
-
-For those looking to delve deeper or self-host Snaplet, try our user-friendly `snaplet setup` CLI wizard!
+Snaplet can be run using `npx` from [npm](https://www.npmjs.com/), or installed and run as a standalone binary:
 
 <Tabs items={["npx", "curl"]}>
   <Tab>
@@ -25,5 +20,8 @@ For those looking to delve deeper or self-host Snaplet, try our user-friendly `s
   </Tab>
 </Tabs>
 
+From there, Snaplet can either be self-hosted or accessed as a web app via our cloud service, Snaplet cloud. The choice is yours!
 
-When you run `snaplet setup`, you will be asked a few questions to complete setup, and generate a [`snaplet.config.ts`](/reference/configuration) configuration file for your project.
+We recommend beginning with [Snaplet cloud](https://snaplet.dev). Sign up for free and start utilizing your data in mere minutes!
+
+For those looking to delve deeper or self-host Snaplet, check out our [self-hosting guide](/snapshot/guides/self-hosting).


### PR DESCRIPTION
The docs suggest the user will get a `snaplet.config.ts` when they run `snaplet setup` to use for local snapshot use case, but this is no longer the case. This PR fixes this by showing the installation steps that apply for both cloud and local usage, then sends a link to the guide to use for local usage.