### PR TITLE
Fix anchor link for using connect option

### DIFF
--- a/pages/seed/core-concepts.mdx
+++ b/pages/seed/core-concepts.mdx
@@ -134,7 +134,7 @@ console.log(seed.$store);
 #### Local stores
 
 Each plan produces its own store and returns it when executed.
-It's particularly useful for the [`connect` option](/core-concepts/seed#using-connect-option).
+It's particularly useful for the [`connect` option](/core-concepts/seed#using-the-connect-option).
 
 ```ts
 const postsStore = await seed.posts(x => x(3));


### PR DESCRIPTION
This fixes a broken anchor link in the core-concepts docs.