### PR TITLE
Update API IP to whitelist

### DIFF
--- a/pages/snapshot/guides/postgresql.mdx
+++ b/pages/snapshot/guides/postgresql.mdx
@@ -63,7 +63,7 @@ Snaplet uses these IPs to connect to your database:
 ```bash
 3.67.57.100
 3.68.126.236
-35.158.181.77
+35.158.237.73
 ```
 
 It's a good idea to restrict all traffic to PostgreSQL, and only grant access where it's absolutely required.

--- a/pages/snapshot/recipes/aws.mdx
+++ b/pages/snapshot/recipes/aws.mdx
@@ -19,7 +19,7 @@ To allow access to your AWS RDS PostgreSQL database, you need to configure the a
 
     Type: PostgreSQL
     Port Range: 5432 (default PostgreSQL port)
-    Source: Snaplet uses `3.67.57.100`, `3.68.126.236` and `35.158.181.77` to connect to your database. You will have to add each IP address as a seperate rule.
+    Source: Snaplet uses `3.67.57.100`, `3.68.126.236` and `35.158.237.73` to connect to your database. You will have to add each IP address as a seperate rule.
 
     Click "Save rules."
 


### PR DESCRIPTION
We changed our API IP to solve a DNS blocking issue with ISPs in Italy, we need to update our docs where we mention which IPs need to be whitelisted in the user's db.