### PR TITLE
feat: config path in package.json

### DIFF
--- a/pages/seed/integrations/prisma.mdx
+++ b/pages/seed/integrations/prisma.mdx
@@ -82,7 +82,7 @@ With this change, the database will be seeded with the data you specified in you
 Whenever your database structure changes (e.g after a new migration is applied), `@snaplet/seed` will need be regenerated to reflect the new structure. To do this, run the following command:
 
 ```bash >_&nbsp;terminal
-npx @snaplet/seed --config prisma/seed/seed.config.ts sync
+npx @snaplet/seed sync
 ```
 
 If you want to automate this process, you can add a [post script](https://docs.npmjs.com/cli/v10/using-npm/scripts#pre--post-scripts) to your `package.json` file:
@@ -90,6 +90,6 @@ If you want to automate this process, you can add a [post script](https://docs.n
 ```json package.json
 "scripts": {
   "migrate": "prisma migrate dev",
-  "postmigrate": "npx @snaplet/seed --config prisma/seed/seed.config.ts sync"
+  "postmigrate": "npx @snaplet/seed sync"
 }
 ```

--- a/pages/seed/reference/configuration.mdx
+++ b/pages/seed/reference/configuration.mdx
@@ -2,6 +2,22 @@
 
 Seed configuration is done in the `seed.client.ts` file.
 
+## Config Location
+
+The default location is `seed.client.ts` in the root of your project.
+
+You can also specify a custom location using the [`--config`](/seed/reference/cli#common-options) flag when running the Seed CLI commands.
+
+If you want to persist your custom location to avoid having to use `--config` for every command, you can add a `@snaplet/seed` field to your `package.json` file.
+
+```json package.json
+{
+  "@snaplet/seed": {
+    "config": "prisma/seed/seed.config.ts"
+  }
+}
+```
+
 ## Config Intellisense
 
 You can use the `defineConfig` helper to define your configuration. This will provide you with intellisense for the available options.


### PR DESCRIPTION
Now that the custom config path is persisted to package.json during `init`, I can remove the `--config` options from the Prisma integration.